### PR TITLE
fix: Failed to fetch dynamically imported module #35

### DIFF
--- a/src/Ljbc1994.Blazor.IntersectionObserver/IntersectionObserverService.cs
+++ b/src/Ljbc1994.Blazor.IntersectionObserver/IntersectionObserverService.cs
@@ -11,7 +11,7 @@ namespace Ljbc1994.Blazor.IntersectionObserver
 {
     public class IntersectionObserverService: IIntersectionObserverService, IAsyncDisposable
     {
-        private readonly string scriptPath = "/_content/BlazorIntersectionObserver/blazor-intersection-observer.min.js";
+        private readonly string scriptPath = "_content/BlazorIntersectionObserver/blazor-intersection-observer.min.js";
 
         private readonly Task<IJSObjectReference> moduleTask;
 


### PR DESCRIPTION
This commit fixes issue #35 by using NavigationManager service injection to create an absolute uri for the .js file in the _content folder, obeying non-root app locations and custom base urls.